### PR TITLE
fix: CARITAS-943

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11
+FROM eclipse-temurin:11-jdk-jammy
 VOLUME ["/tmp","/log"]
 EXPOSE 8080
 ARG JAR_FILE


### PR DESCRIPTION
Update Docker base image from `adoptopenjdk/openjdk11` to `eclipse-temurin:11-jdk-jammy`.

adoptopenjdk is deprecated; eclipse-temurin is its official successor. Same JDK 11, no other Dockerfile changes required.

Ref: CARITAS-943